### PR TITLE
Add support for 9 digit zip codes

### DIFF
--- a/SwiftValidator/Rules/ZipCodeRule.swift
+++ b/SwiftValidator/Rules/ZipCodeRule.swift
@@ -18,7 +18,7 @@ public class ZipCodeRule: RegexRule {
      - parameter message: String that holds error message.
      - returns: An initialized object, or nil if an object could not be created for some reason that would not result in an exception.
      */
-    public convenience init(message : String = "Enter a valid 5 digit zipcode"){
-        self.init(regex: "\\d{5}", message : message)
+    public convenience init(message : String = "Enter a valid 5 or 9 digit zipcode"){
+        self.init(regex: "\\d{5}(-\\d{4})?", message : message)
     }
 }


### PR DESCRIPTION
The **ZIP+4** format of zip codes ([introduced in 1983](https://en.wikipedia.org/wiki/ZIP_Code)) allows for greater precision by appending a hyphen and 4 digits to the zip code. 

For example, in Austin, TX one of the **ZIP+4** codes is `78758-2585`.

I added in regex support for 9 digit zip codes as well as 5 digit ones. Let me know if there's anything else I can help with! Thanks.
