### PR TITLE
Update RegexRule + RequiredRule

### DIFF
--- a/SwiftValidator/Rules/RegexRule.swift
+++ b/SwiftValidator/Rules/RegexRule.swift
@@ -11,7 +11,7 @@ import Foundation
 /**
  `RegexRule` is a subclass of Rule that defines how a regular expression is validated.
  */
-public class RegexRule : Rule {
+open class RegexRule : Rule {
     /// Regular express string to be used in validation.
     private var REGEX: String = "^(?=.*?[A-Z]).{8,}$"
     /// String that holds error message.
@@ -35,7 +35,7 @@ public class RegexRule : Rule {
      - parameter value: String to checked for validation.
      - returns: Boolean value. True if validation is successful; False if validation fails.
      */
-    public func validate(_ value: String) -> Bool {
+    open func validate(_ value: String) -> Bool {
         let test = NSPredicate(format: "SELF MATCHES %@", self.REGEX)
         return test.evaluate(with: value)
     }
@@ -45,7 +45,7 @@ public class RegexRule : Rule {
      
      - returns: String of error message.
      */
-    public func errorMessage() -> String {
+    open func errorMessage() -> String {
         return message
     }
 }

--- a/SwiftValidator/Rules/RequiredRule.swift
+++ b/SwiftValidator/Rules/RequiredRule.swift
@@ -11,7 +11,7 @@ import Foundation
 /**
  `RequiredRule` is a subclass of Rule that defines how a required field is validated.
  */
-public class RequiredRule: Rule {
+open class RequiredRule: Rule {
     /// String that holds error message.
     private var message : String 
     
@@ -31,7 +31,7 @@ public class RequiredRule: Rule {
      - parameter value: String to checked for validation.
      - returns: Boolean value. True if validation is successful; False if validation fails.
      */
-    public func validate(_ value: String) -> Bool {
+    open func validate(_ value: String) -> Bool {
         return !value.isEmpty
     }
     
@@ -40,7 +40,7 @@ public class RequiredRule: Rule {
      
      - returns: String of error message.
      */
-    public func errorMessage() -> String {
+    open func errorMessage() -> String {
         return message
     }
 }


### PR DESCRIPTION
Setting **RegexRule** and **RequiredRule** classes to "open class" in order to allow subclassing in Swift 3
Also **validate** and **errorMessage** methods in both classes also set to "open method" for the same reason.