### PR TITLE
UITextField Validatable extension.

### DIFF
--- a/SwiftValidator/Core/Validatable.swift
+++ b/SwiftValidator/Core/Validatable.swift
@@ -19,7 +19,7 @@ public protocol Validatable {
 
 extension UITextField: Validatable {
     
-    public var validationText: String {
+    open var validationText: String {
         return text ?? ""
     }
 }


### PR DESCRIPTION
We have custom uitextfield which is setting uitextfiled's text to double and when is your component is validating we need to use localization. We changed your component to ovveritable.     