### PR TITLE
Modify unregisterField method

### DIFF
--- a/SwiftValidator/Core/Validator.swift
+++ b/SwiftValidator/Core/Validator.swift
@@ -120,6 +120,7 @@ public class Validator {
     public func unregisterField(_ field:ValidatableField) {
         validations.removeValueForKey(field)
         errors.removeValueForKey(field)
+        fields.removeValueForKey(field)
     }
     
     /**


### PR DESCRIPTION
When dynamically creating controls and registering them, they are not deallocated when they are unregistered, I figured the cause could probably be the fields dictionary keeping a reference to them.
Here is my snippet of code:

 merchant.visibleParams?.map { $0.associatedControl }.forEach { control in
                control.onChange = { _ in self.validate() }
                self.validator.registerField(control, rules: [RequiredRule()]) //here I register
                section.elements.append(control)
            }

When I update the UI and unregister those controls, they are not deallocated:

       node.subnodes?.filter { $0.debugName == "dynamic" }.forEach {  control in
            self.validator.unregisterField(control as! ValidatableField)
        }
